### PR TITLE
Make DC10 a past event and add video content

### DIFF
--- a/_includes/event-status.html
+++ b/_includes/event-status.html
@@ -1,9 +1,9 @@
-<!-- <div class="event-status">
+<div class="event-status">
   <img src="img/logo.png" class="event-status__logo">
   <h3 class="event-status__price text-upper">Next event tbc</h3>
-</div> -->
+</div>
 
-<div class="event-status">
+<!-- <div class="event-status">
   <img src="img/logo.png" class="event-status__logo">
   <h3 class="event-status__date text-upper">25th Feb</h3>
   <h3 class="event-status__venue text-upper">Monzo HQ, Finsbury Square</h3>
@@ -11,3 +11,4 @@
   <a href="{% include ticket-link.html %}" target="_blank"
   class="event-status__buy link-invert--plain text-heavy text-upper">{% include cta.html %}</a>
 </div>
+ -->

--- a/_includes/latest-blog.html
+++ b/_includes/latest-blog.html
@@ -1,15 +1,24 @@
 <div id="blog" class="container bg-base-light">
-  <p class="text-secondary">Latest from the blog</p>
+  <p class="text-secondary">Latest</p>
   <div class="grid u-cf u-margin-Tm">
     {% for post in site.categories.blog limit:2 %}
-      <div class="grid__left grid__left--latest-blog">
-        <img src="img/blog/{{ post.pic }}" class="u-margin-Bs">
-        <h3 class="u-margin-Bs">
-          <a href="{{ post.link }}" target="_blank" class="link-plain">{{ post.title }}</a>
-        </h3>
-        <p class="u-margin-Bs">{{ post.preview }}&hellip;</p>
-        <a href="{{ post.link }}" target="_blank">Read full article &rarr;</a>
-      </div>
+      {% if post.pic %}
+        <div class="grid__left grid__left--latest-blog">
+          <img src="img/blog/{{ post.pic }}" class="u-margin-Bs">
+          <h3 class="u-margin-Bs">
+            <a href="{{ post.link }}" target="_blank" class="link-plain">{{ post.title }}</a>
+          </h3>
+          <p class="u-margin-Bs">{{ post.preview }}&hellip;</p>
+          <a href="{{ post.link }}" target="_blank">Read full article &rarr;</a>
+        </div>
+      {% elsif post.youtubeURL %}
+        <div class="grid__left grid__left--latest-blog">
+          <h3 class="u-margin-Bs">
+            <a href="{{ post.link }}" target="_blank" class="link-plain">{{ post.title }}</a>
+          </h3>
+          <iframe width="100%" height="300px" src="{{ post.youtubeURL }}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        </div>
+      {% endif %}
     {% endfor %}
   </div>
 </div>

--- a/_includes/past-event.html
+++ b/_includes/past-event.html
@@ -5,23 +5,41 @@
       <div class="next-event__about--content">
         <h2 class="u-margin-Bxs">{{ post.pastTitle }}</h2>
         <p class="text-medium u-margin-Bs">
-          {{ post.title }} was on 
-          <span class="text-heavy">{{ post.date | date: "%d %B" }}</span> at 
-          <span class="text-heavy">{{ post.venueName }}</span> in 
-          {{ post.venueLocation }}. Check out the details below:
-        </p> 
-        <a href="{{ post.pastWriteup }}" class="text-medium u-block" target="_blank">
-        Read the full write-up &rarr;</a>
-        <a href="{{ post.pastPhotos }}" class="text-medium" target="_blank">
-        View the photos &rarr;</a>
+          {{ post.title }} was on
+          <span class="text-heavy">{{ post.date | date: "%d %B" }}</span> at
+          <span class="text-heavy">{{ post.venueName }}</span> in
+          {{ post.venueLocation }}.
+        </p>
+
+        {% if post.pastWriteup %}
+          <a href="{{ post.pastWriteup }}" class="text-medium u-block" target="_blank">Read the full write-up &rarr;</a>
+        {% endif %}
+
+        {% if post.pastPhotos %}
+          <a href="{{ post.pastPhotos }}" class="text-medium" target="_blank">View the photos &rarr;</a>
+        {% endif %}
       </div>
     </div>
-    <div class="past-event grid__right" style="
-      background: url(../img/blog/{{ post.pastPic }}) no-repeat center center;
-      -webkit-background-size: cover;
-      -moz-background-size: cover;
-      -o-background-size: cover;
-      background-size: cover;">
-    </div>
+    {% if post.pastPic %}
+      <div class="past-event grid__right" style="
+        background: url(../img/blog/{{ post.pastPic }}) no-repeat center center;
+        -webkit-background-size: cover;
+        -moz-background-size: cover;
+        -o-background-size: cover;
+        background-size: cover;">
+      </div>
+    {% elsif post.youtubeURL %}
+      <div class="past-event grid__right">
+          <iframe width="100%" height="100%" src="{{post.youtubeURL}}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </div>
+    {% else %}
+      <div class="past-event grid__right" style="
+        background: url(../img/no-event.jpg) no-repeat center center;
+        -webkit-background-size: cover;
+        -moz-background-size: cover;
+        -o-background-size: cover;
+        background-size: cover;">
+      </div>
+    {% endif %}
   </div>
 </div>

--- a/_posts/2019-11-19-design-club-10-write-up.md
+++ b/_posts/2019-11-19-design-club-10-write-up.md
@@ -1,0 +1,10 @@
+---
+title: Design Club 10
+date: 2020-02-25 00:00:00 Z
+categories:
+- blog
+layout: default
+link:
+preview:
+youtubeURL: https://www.youtube.com/embed/phxz9j28r90
+---

--- a/_posts/2019-11-19-design-club-10.md
+++ b/_posts/2019-11-19-design-club-10.md
@@ -25,9 +25,10 @@ speakerTwoJob: Lead Designer, Bulb
 speakerTwoTwitter: "@thatnatbuckley"
 speakerTwoBio: You want your team to form like Voltron, but it’s a bit like a dog playing Jenga? Great teams are more than the sum of their parts, but to get there you need to create a work culture where everyone’s skills and knowledge can be freely shared. Nat will talk about the way Bulb is building content, design and research culture, bringing together people across disciplines to do their best work together.
 
-status: upcoming
+status: past
 pastTitle:
 pastWriteup:
 pastPic:
 pastPhotos:
+youtubeURL: https://www.youtube.com/embed/phxz9j28r90
 ---

--- a/_posts/2019-11-19-design-club-9-write-up.md
+++ b/_posts/2019-11-19-design-club-9-write-up.md
@@ -1,0 +1,11 @@
+---
+title: Design Club 9
+date: 2019-11-19 00:00:00 Z
+categories:
+- blog
+layout: default
+link:
+preview:
+youtubeURL: https://www.youtube.com/embed/9eyUeHFo6So
+---
+

--- a/_posts/2019-11-19-design-club-9.md
+++ b/_posts/2019-11-19-design-club-9.md
@@ -26,4 +26,5 @@ pastTitle:
 pastWriteup:
 pastPic:
 pastPhotos:
+youtubeURL: https://www.youtube.com/embed/9eyUeHFo6So
 ---


### PR DESCRIPTION
This change just ensures that we have torn down the DC10 event and that
we have embeds of the YouTube videos. We also took the chance to make a
few improvements to the events page e.g. fallback event image & removal
of broken links.